### PR TITLE
Laser Postion Settings

### DIFF
--- a/app.py
+++ b/app.py
@@ -217,10 +217,10 @@ def update_source_postions(sources_coordinates_input,sources_display_input,x1_in
     sources_display = sources_display_input
     
     if ctx.triggered_id == "add_source": #Checking if add source button is clicked
-        if not add_source_coordinates in sources_coordinates: #Check if new source positiond isn't overlaping with already existing sources
+        if not add_source_coordinates in sources_coordinates: #Check if new source positiond isn't overlapping with already existing sources
             sources_coordinates.append(add_source_coordinates)
         else:
-            #Return warning if postions are overlaping
+            #Return warning if postions are overlapping
             return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display, 
                     x1_out=x1_in, y1_out=y1_in, z1_out=z1_in,
                     x2_out=x2_in, y2_out=y2_in, z2_out=z2_in,
@@ -266,9 +266,9 @@ def update_source_postions(sources_coordinates_input,sources_display_input,x1_in
     if ctx.triggered_id=="primary_source_x_coordinate" or ctx.triggered_id=="primary_source_y_coordinate"  or ctx.triggered_id=="primary_source_z_coordinate" :#If we change first source's position
         x,y,z = x1_in, y1_in, z1_in
         if len(sources_coordinates)==3:
-            #Checking if changed position isn't overlaping with already existing ones    
+            #Checking if changed position isn't overlapping with already existing ones    
             if [x,y,z] in sources_coordinates[1:2]:
-                #Prevent change and raise warning about overlaping positions
+                #Prevent change and raise warning about overlapping positions
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=sources_coordinates[0][0], y1_out=sources_coordinates[0][1], z1_out=sources_coordinates[0][2],
                     x2_out=x2_in, y2_out=y2_in, z2_out=z2_in,
@@ -276,7 +276,7 @@ def update_source_postions(sources_coordinates_input,sources_display_input,x1_in
                     warning1=True,warning2=False,warning3=False,
                     new_warning=False)
             else:
-                #If positions aren't overlaping, change the position of first source
+                #If positions aren't overlapping, change the position of first source
                 sources_coordinates[0] = [x,y,z]
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x, y1_out=y, z1_out=z,
@@ -285,9 +285,9 @@ def update_source_postions(sources_coordinates_input,sources_display_input,x1_in
                     warning1=False,warning2=False,warning3=False,
                     new_warning=False)
         elif len(sources_coordinates)==2:
-            #Checking if changed position isn't overlaping with already existing ones    
+            #Checking if changed position isn't overlapping with already existing ones    
             if [x,y,z] in sources_coordinates[1]:
-                #Prevent change and raise warning about overlaping positions
+                #Prevent change and raise warning about overlapping positions
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=sources_coordinates[0][0], y1_out=sources_coordinates[0][1], z1_out=sources_coordinates[0][2],
                     x2_out=x2_in, y2_out=y2_in, z2_out=z2_in,
@@ -295,7 +295,7 @@ def update_source_postions(sources_coordinates_input,sources_display_input,x1_in
                     warning1=True,warning2=False,warning3=False,
                     new_warning=False)
             else:
-                #If positions aren't overlaping, change the position of first source
+                #If positions aren't overlapping, change the position of first source
                 sources_coordinates[0] = [x,y,z]
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x, y1_out=y, z1_out=z,
@@ -319,9 +319,9 @@ def update_source_postions(sources_coordinates_input,sources_display_input,x1_in
     if ctx.triggered_id=="secondary_source_x_coordinate" or ctx.triggered_id=="secondary_source_y_coordinate"  or ctx.triggered_id=="secondary_source_z_coordinate":
         x,y,z = x2_in, y2_in, z2_in
         if len(sources_coordinates)==3:
-            #Checking if changed position isn't overlaping with already existing ones    
+            #Checking if changed position isn't overlapping with already existing ones    
             if [x,y,z] in [sources_coordinates[0],sources_coordinates[2]]:
-                #Prevent change and raise warning about overlaping positions
+                #Prevent change and raise warning about overlapping positions
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x1_in, y1_out=y1_in, z1_out=z1_in,
                     x2_out=sources_coordinates[1][0], y2_out=sources_coordinates[1][1], z2_out=sources_coordinates[1][2],
@@ -329,7 +329,7 @@ def update_source_postions(sources_coordinates_input,sources_display_input,x1_in
                     warning1=False,warning2=True,warning3=False,
                     new_warning=False)
             else:
-                #If positions aren't overlaping, change the position of second source
+                #If positions aren't overlapping, change the position of second source
                 sources_coordinates[1] = [x,y,z]
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x1_in, y1_out=y1_in, z1_out=z1_in,
@@ -338,9 +338,9 @@ def update_source_postions(sources_coordinates_input,sources_display_input,x1_in
                     warning1=False,warning2=False,warning3=False,
                     new_warning=False)
         elif len(sources_coordinates)==2:
-            #Checking if changed position isn't overlaping with already existing ones
+            #Checking if changed position isn't overlapping with already existing ones
             if [x,y,z] in sources_coordinates[0]:
-                #Prevent change and raise warning about overlaping positions
+                #Prevent change and raise warning about overlapping positions
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x1_in, y1_out=y1_in, z1_out=z1_in,
                     x2_out=sources_coordinates[1][0], y2_out=sources_coordinates[1][1], z2_out=sources_coordinates[1][2],
@@ -348,7 +348,7 @@ def update_source_postions(sources_coordinates_input,sources_display_input,x1_in
                     warning1=False,warning2=True,warning3=False,
                     new_warning=False)
             else:
-                #If positions aren't overlaping, change the position of second source
+                #If positions aren't overlapping, change the position of second source
                 sources_coordinates[1] = [x,y,z]
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x1_in, y1_out=y1_in, z1_out=z1_in,
@@ -363,9 +363,9 @@ def update_source_postions(sources_coordinates_input,sources_display_input,x1_in
     if ctx.triggered_id=="third_source_x_coordinate" or ctx.triggered_id=="third_source_y_coordinate"  or ctx.triggered_id=="third_source_z_coordinate":
         x,y,z = x3_in, y3_in, z3_in
         if len(sources_coordinates)==3:   
-            #Checking if changed position isn't overlaping with already existing ones 
+            #Checking if changed position isn't overlapping with already existing ones 
             if [x,y,z] in [sources_coordinates[0],sources_coordinates[1]]:
-                #Prevent change and raise warning about overlaping positions
+                #Prevent change and raise warning about overlapping positions
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x1_in, y1_out=y1_in, z1_out=z1_in,
                     x2_out=x2_in, y2_out=y2_in, z2_out=z2_in,
@@ -373,7 +373,7 @@ def update_source_postions(sources_coordinates_input,sources_display_input,x1_in
                     warning1=False,warning2=False,warning3=True,
                     new_warning=False)
             else:
-                #If positions aren't overlaping, change the position of third source
+                #If positions aren't overlapping, change the position of third source
                 sources_coordinates[2] = [x,y,z]
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x1_in, y1_out=y1_in, z1_out=z1_in,
@@ -384,7 +384,7 @@ def update_source_postions(sources_coordinates_input,sources_display_input,x1_in
         else:
             #Prevent auto update when we don't have any sources
             raise PreventUpdate
-    #Preventing postions when we refresh app
+    #Preserving postions when we refresh app
     if len(sources_coordinates) == 0:
         return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x1_in, y1_out=y1_in, z1_out=z1_in,

--- a/app.py
+++ b/app.py
@@ -104,11 +104,11 @@ app.layout = html.Div([
                                             html.Div(id="add_source_position_parameters", style={"display":"block"},
                                                     children=[                                            
                                                         html.Label("X (mm): ", htmlFor="add_source_x_coordinate"),
-                                                        dcc.Input(id="add_source_x_coordinate", type="number", min=0, step=0.001, value=0),
+                                                        dcc.Input(id="add_source_x_coordinate", type="number", min=0, step=0.001, value=0, debounce=True),
                                                         html.Label("Y (mm): ", htmlFor="add_source_y_coordinate"),
-                                                        dcc.Input(id="add_source_y_coordinate", type="number", min=0, step=0.001, value=0),
+                                                        dcc.Input(id="add_source_y_coordinate", type="number", min=0, step=0.001, value=0, debounce=True),
                                                         html.Label("Z (mm): ", htmlFor="add_source_z_coordinate"),
-                                                        dcc.Input(id="add_source_z_coordinate", type="number", min=0, step=0.001, value=0),
+                                                        dcc.Input(id="add_source_z_coordinate", type="number", min=0, step=0.001, value=0, debounce=True),
                                                         html.Button("Add source", id="add_source", n_clicks=0, disabled=False),
                                                         dcc.ConfirmDialog(id="sources_with_overlapping_coordinates", message="Can't add source because of overlapping coordinates")
                                                     ]),
@@ -117,11 +117,11 @@ app.layout = html.Div([
                                                         html.Label("Primary source: ", htmlFor="primary_source"), 
                                                         html.Br(),
                                                         html.Label("X (mm): ", htmlFor="primary_source_x_coordinate"),
-                                                        dcc.Input(id="primary_source_x_coordinate", type="number", min=0, step=0.001,persistence = True, persistence_type = 'session', persisted_props=['value']),
+                                                        dcc.Input(id="primary_source_x_coordinate", type="number", min=0, step=0.001, debounce=True),
                                                         html.Label("Y (mm): ", htmlFor="primary_source_y_coordinate"),
-                                                        dcc.Input(id="primary_source_y_coordinate", type="number", min=0, step=0.001,persistence = True, persistence_type = 'session'),
+                                                        dcc.Input(id="primary_source_y_coordinate", type="number", min=0, step=0.001, debounce=True),
                                                         html.Label("Z (mm): ", htmlFor="primary_source_z_coordinate"),
-                                                        dcc.Input(id="primary_source_z_coordinate", type="number", min=0, step=0.001,persistence = True, persistence_type = 'session'),
+                                                        dcc.Input(id="primary_source_z_coordinate", type="number", min=0, step=0.001, debounce=True),
                                                         dcc.ConfirmDialog(id="primary_source_coordinates_overlap", message="Primary source can't overlap with another source")
                                                     ]),
                                             html.Div(id="secondary_source_position_parameters", style={"display":"none"},
@@ -129,11 +129,11 @@ app.layout = html.Div([
                                                         html.Label("Secondary source: ", htmlFor="secondary_source"),
                                                         html.Br(),
                                                         html.Label("X (mm): ", htmlFor="secondary_source_x_coordinate"),
-                                                        dcc.Input(id="secondary_source_x_coordinate", type="number", min=0, step=0.001),
+                                                        dcc.Input(id="secondary_source_x_coordinate", type="number", min=0, step=0.001, debounce=True),
                                                         html.Label("Y (mm): ", htmlFor="secondary_source_y_coordinate"),
-                                                        dcc.Input(id="secondary_source_y_coordinate", type="number", min=0, step=0.001),
+                                                        dcc.Input(id="secondary_source_y_coordinate", type="number", min=0, step=0.001, debounce=True),
                                                         html.Label("Z (mm): ", htmlFor="secondary_source_z_coordinate"),
-                                                        dcc.Input(id="secondary_source_z_coordinate", type="number", min=0, step=0.001),
+                                                        dcc.Input(id="secondary_source_z_coordinate", type="number", min=0, step=0.001, debounce=True),
                                                         dcc.ConfirmDialog(id="secondary_source_coordinates_overlap", message="Secondary source can't overlap with another source")
                                                     ]),
                                             html.Div(id="third_source_position_parameters", style={"display":"none"},
@@ -141,11 +141,11 @@ app.layout = html.Div([
                                                         html.Label("Third source: ", htmlFor="third_source"),
                                                         html.Br(),
                                                         html.Label("X (mm): ", htmlFor="third_source_x_coordinate"),
-                                                        dcc.Input(id="third_source_x_coordinate", type="number", min=0, step=0.001),
+                                                        dcc.Input(id="third_source_x_coordinate", type="number", min=0, step=0.001, debounce=True),
                                                         html.Label("Y (mm): ", htmlFor="third_source_y_coordinate"),
-                                                        dcc.Input(id="third_source_y_coordinate", type="number", min=0, step=0.001),
+                                                        dcc.Input(id="third_source_y_coordinate", type="number", min=0, step=0.001, debounce=True),
                                                         html.Label("Z (mm): ", htmlFor="third_source_z_coordinate"),
-                                                        dcc.Input(id="third_source_z_coordinate", type="number", min=0, step=0.001),
+                                                        dcc.Input(id="third_source_z_coordinate", type="number", min=0, step=0.001, debounce=True),
                                                         dcc.ConfirmDialog(id="third_source_coordinates_overlap", message="Third source can't overlap with another source")
                                                     ]),
                                             html.Button("Remove last source", id="remove_source", n_clicks=0, disabled=True),
@@ -285,8 +285,11 @@ def update_source_postions(sources_coordinates_input,sources_display_input,x1_in
                     warning1=False,warning2=False,warning3=False,
                     new_warning=False)
         elif len(sources_coordinates)==2:
+            print("len2")
+            print([x,y,z], sources_coordinates[1])
             #Checking if changed position isn't overlapping with already existing ones    
-            if [x,y,z] in sources_coordinates[1]:
+            if [x,y,z] == sources_coordinates[1]:
+                print("1 as 2")
                 #Prevent change and raise warning about overlapping positions
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=sources_coordinates[0][0], y1_out=sources_coordinates[0][1], z1_out=sources_coordinates[0][2],
@@ -339,7 +342,7 @@ def update_source_postions(sources_coordinates_input,sources_display_input,x1_in
                     new_warning=False)
         elif len(sources_coordinates)==2:
             #Checking if changed position isn't overlapping with already existing ones
-            if [x,y,z] in sources_coordinates[0]:
+            if [x,y,z] == sources_coordinates[0]:
                 #Prevent change and raise warning about overlapping positions
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x1_in, y1_out=y1_in, z1_out=z1_in,

--- a/app.py
+++ b/app.py
@@ -285,11 +285,8 @@ def update_source_postions(sources_coordinates_input,sources_display_input,x1_in
                     warning1=False,warning2=False,warning3=False,
                     new_warning=False)
         elif len(sources_coordinates)==2:
-            print("len2")
-            print([x,y,z], sources_coordinates[1])
             #Checking if changed position isn't overlapping with already existing ones    
             if [x,y,z] == sources_coordinates[1]:
-                print("1 as 2")
                 #Prevent change and raise warning about overlapping positions
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=sources_coordinates[0][0], y1_out=sources_coordinates[0][1], z1_out=sources_coordinates[0][2],

--- a/app.py
+++ b/app.py
@@ -201,7 +201,9 @@ def update_number_of_sources(add_source, remove_source, add_source_x_coordinate,
             return sources_display_list, True #Display error message and prevent form adding overlaping sources  
     if ctx.triggered_id == "remove_source": #Remove last source
         sources_coordinates_list.pop()
-    
+        for i in range(3):
+            sources_display_list[i]={"display":"none"}
+
     number_of_sources = len(sources_coordinates_list)
 
     for i in range(number_of_sources):#Update display list based on current no. of sources
@@ -215,6 +217,9 @@ def update_number_of_sources(add_source, remove_source, add_source_x_coordinate,
     Input("remove_source", "n_clicks")
 )
 def disable_source_buttons(add_source, remove_source):
+    """
+    Disabling adding and removing buttons
+    """
     if len(sources_coordinates_list) == 0:
         return False, True
     
@@ -271,53 +276,48 @@ def update_third_source_coordinates(add_source, *add_source_coordinates):
         return add_source_coordinates
     
     raise PreventUpdate
+@callback(
+    [Output("primary_source_coordinates_overlap", "displayed"),[Output("primary_source_x_coordinate", "value",allow_duplicate=True), Output("primary_source_y_coordinate", "value",allow_duplicate=True), Output("primary_source_z_coordinate", "value",allow_duplicate=True)]],
+    [Input("primary_source_x_coordinate", "value"), Input("primary_source_y_coordinate", "value"), Input("primary_source_z_coordinate", "value")],
+    prevent_initial_call='initial_duplicate'
+)
+def display_primary_source_coordinates_overlaping_warning(x,y,z):
+    if [x,y,z] in sources_coordinates_list[1:2]:
+        return True, sources_coordinates_list[0]
+    else:
+        sources_coordinates_list[0] = [x,y,z]
+        return False, [x,y,z]
 
 @callback(
-    Output("sources_with_overlapping_coordinates", "displayed"),
-    Input("add_source", "n_clicks"),
+    [Output("secondary_source_coordinates_overlap", "displayed"),[Output("secondary_source_x_coordinate", "value",allow_duplicate=True), Output("secondary_source_y_coordinate", "value",allow_duplicate=True), Output("secondary_source_z_coordinate", "value",allow_duplicate=True)]],
+    [Input("secondary_source_x_coordinate", "value"), Input("secondary_source_y_coordinate", "value"), Input("secondary_source_z_coordinate", "value")],
+    prevent_initial_call='initial_duplicate'
 )
-def display_cant_add_source_warning(add_source):
-    if ctx.triggered_id == "add_source":
-        duplicate_coordinates = [coordinates for coordinates in sources_coordinates_list if sources_coordinates_list.count(coordinates) > 1]
-
-        if len(duplicate_coordinates):
-            return True
-
-    return False
-
+def display_secondary_source_coordinates_overlaping_warning(x,y,z):
+    if len(sources_coordinates_list)==3:
+        if [x,y,z] in [sources_coordinates_list[0],sources_coordinates_list[2]]:
+            return True, sources_coordinates_list[1]
+        else:
+            sources_coordinates_list[1] = [x,y,z]
+            return False, [x,y,z]
+    else:
+        if [x,y,z] == sources_coordinates_list[0]:
+            return True, sources_coordinates_list[1]
+        else:
+            sources_coordinates_list[1] = [x,y,z]
+            return False, [x,y,z]
 @callback(
-    Output("primary_source_coordinates_overlap", "displayed"),
-    [Input("primary_source_x_coordinate", "value"), Input("primary_source_y_coordinate", "value"), Input("primary_source_z_coordinate", "value")]
+    [Output("third_source_coordinates_overlap", "displayed"),[Output("third_source_x_coordinate", "value",allow_duplicate=True), Output("third_source_y_coordinate", "value",allow_duplicate=True), Output("third_source_z_coordinate", "value",allow_duplicate=True)]],
+    [Input("third_source_x_coordinate", "value"), Input("third_source_y_coordinate", "value"), Input("third_source_z_coordinate", "value")],
+    prevent_initial_call='initial_duplicate'
 )
-def display_primary_source_coordinates_overlaping_warning(*primary_source_coordinates):
-    if (ctx.triggered_id.startswith("primary") and
-        sources_coordinates_list.count(primary_source_coordinates) > 1):
-        return True
-
-    return False
-
-@callback(
-    Output("secondary_source_coordinates_overlap", "displayed"),
-    [Input("secondary_source_x_coordinate", "value"), Input("secondary_source_y_coordinate", "value"), Input("secondary_source_z_coordinate", "value")]
-)
-def display_secondary_source_coordinates_overlaping_warning(*secondary_source_coordinates):
-    if (ctx.triggered_id.startswith("secondary") and
-        sources_coordinates_list.count(secondary_source_coordinates) > 1):
-        return True
-
-    return False
-
-@callback(
-    Output("third_source_coordinates_overlap", "displayed"),
-    [Input("third_source_x_coordinate", "value"), Input("third_source_y_coordinate", "value"), Input("third_source_z_coordinate", "value")]
-)
-def display_third_source_coordinates_overlaping_warning(*third_source_coordinates):
-    if (ctx.triggered_id.startswith("third") and
-        sources_coordinates_list.count(third_source_coordinates) > 1):
-        return True
-
-    return False
-
+def display_third_source_coordinates_overlaping_warning(x,y,z):
+    if [x,y,z] in [sources_coordinates_list[0],sources_coordinates_list[1]]:
+        return True, sources_coordinates_list[2]
+    else:
+        sources_coordinates_list[2] = [x,y,z]
+        return False, [x,y,z]
 
 if __name__ == '__main__':
     app.run(debug=True)
+    

--- a/app.py
+++ b/app.py
@@ -2,11 +2,13 @@ from dash import Dash, html, dcc, Input, Output, ctx, callback
 from dash.exceptions import PreventUpdate
 import json
 
+#Reading data from json file
 with open("assets/tissues.json") as tissues_json:
     tissues = json.load(tissues_json)
 
 app = Dash(__name__)
 
+#Variables 
 memory = html.Div([
     dcc.Store(id="sources_coordinates_list", data=[], storage_type="session"),
     dcc.Store(id="sources_display_list", data=[{"display":"none"},{"display":"none"},{"display":"none"}], storage_type="session")
@@ -166,6 +168,9 @@ app.layout = html.Div([
     Input("no_of_voxel_z","value"),
 )
 def calculate_dim(voxel_dim, no_of_voxel_x, no_of_voxel_y, no_of_voxel_z):
+    """
+    Calculating size of ROI
+    """
     return round(voxel_dim*no_of_voxel_x,3), round(voxel_dim*no_of_voxel_y,3), round(voxel_dim*no_of_voxel_z,3)
 
 #Tissue Callbacks
@@ -178,6 +183,9 @@ def calculate_dim(voxel_dim, no_of_voxel_x, no_of_voxel_y, no_of_voxel_z):
     Input("tissue_select","value")
 )
 def update_tissue(tissue):
+    """
+    Reading tissue parameters form tissues.json
+    """
     wave_param = tissues[tissue]["Optical parameters"]["Wave length"]
     native = list(tissues[tissue]["Optical parameters"]["Native"].values())
     coagulated = list(tissues[tissue]["Optical parameters"]["Coagulated"].values())
@@ -200,59 +208,67 @@ def update_tissue(tissue):
                     new_x = Input("add_source_x_coordinate", "value"), new_y = Input("add_source_y_coordinate", "value"), new_z = Input("add_source_z_coordinate", "value"),
                     add_source = Input("add_source","n_clicks"), remove_source = Input("remove_source", "n_clicks"))
 )
-def update_source(sources_coordinates_input,sources_display_input,x1_in,y1_in,z1_in,x2_in,y2_in,z2_in,x3_in,y3_in,z3_in,new_x,new_y,new_z,add_source,remove_source):
-    
-    print("update")
+def update_source_postions(sources_coordinates_input,sources_display_input,x1_in,y1_in,z1_in,x2_in,y2_in,z2_in,x3_in,y3_in,z3_in,new_x,new_y,new_z,add_source,remove_source):
+    """
+    Function to adding, removing and changing postions of sources
+    """
     add_source_coordinates = [new_x,new_y,new_z]
     sources_coordinates = sources_coordinates_input
     sources_display = sources_display_input
     
-    if ctx.triggered_id == "add_source":
-        if not add_source_coordinates in sources_coordinates:
+    if ctx.triggered_id == "add_source": #Checking if add source button is clicked
+        if not add_source_coordinates in sources_coordinates: #Check if new source positiond isn't overlaping with already existing sources
             sources_coordinates.append(add_source_coordinates)
         else:
-            return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
+            #Return warning if postions are overlaping
+            return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display, 
                     x1_out=x1_in, y1_out=y1_in, z1_out=z1_in,
                     x2_out=x2_in, y2_out=y2_in, z2_out=z2_in,
                     x3_out=x3_in, y3_out=y3_in, z3_out=z3_in,
                     warning1=False,warning2=False,warning3=False,
                     new_warning=True)
-    if ctx.triggered_id == "remove_source":
+    if ctx.triggered_id == "remove_source":#Check if remove last source button is clicked. If yes remove last value form source coordinates
         sources_coordinates.pop()
+        #Start of changing display values
         for i in range(3):
             sources_display[i]={"display":"none"}
-    print(sources_coordinates)
-    for i in range(len(sources_coordinates)):
+    for i in range(len(sources_coordinates)): #This probably can be improved !!!
         sources_display[i] = {"display":"block"}
-    print(sources_display)
-    if ctx.triggered_id == "add_source" and len(sources_coordinates)==1:
+    #End of changing display values
+    if ctx.triggered_id == "add_source" and len(sources_coordinates)==1: #If we are adding first source
         x1, y1, z1 = new_x, new_y, new_z
+        #Update first source's position
         return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x1, y1_out=y1, z1_out=z1,
                     x2_out=x2_in, y2_out=y2_in, z2_out=z2_in,
                     x3_out=x3_in, y3_out=y3_in, z3_out=z3_in,
                     warning1=False,warning2=False,warning3=False,
                     new_warning=False)
-    elif ctx.triggered_id == "add_source" and len(sources_coordinates)==2:
+    elif ctx.triggered_id == "add_source" and len(sources_coordinates)==2: #If we are adding second source
         x2, y2, z2 = new_x, new_y, new_z
+        #Update second source's position
         return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x1_in, y1_out=y1_in, z1_out=z1_in,
                     x2_out=x2, y2_out=y2, z2_out=z2,
                     x3_out=x3_in, y3_out=y3_in, z3_out=z3_in,
                     warning1=False,warning2=False,warning3=False,
                     new_warning=False)
-    elif ctx.triggered_id == "add_source" and len(sources_coordinates)==3:
+    elif ctx.triggered_id == "add_source" and len(sources_coordinates)==3: #If we are adding third source
         x3, y3, z3 = new_x, new_y, new_z
+        #Update third source's postion
         return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x1_in, y1_out=y1_in, z1_out=z1_in,
                     x2_out=x2_in, y2_out=y2_in, z2_out=z2_in,
                     x3_out=x3, y3_out=y3, z3_out=z3,
                     warning1=False,warning2=False,warning3=False,
                     new_warning=False)
-    if ctx.triggered_id=="primary_source_x_coordinate" or ctx.triggered_id=="primary_source_y_coordinate"  or ctx.triggered_id=="primary_source_z_coordinate" :
+    #Changing first source's postion
+    if ctx.triggered_id=="primary_source_x_coordinate" or ctx.triggered_id=="primary_source_y_coordinate"  or ctx.triggered_id=="primary_source_z_coordinate" :#If we change first source's position
         x,y,z = x1_in, y1_in, z1_in
-        if len(sources_coordinates)==3:    
+        if len(sources_coordinates)==3:
+            #Checking if changed position isn't overlaping with already existing ones    
             if [x,y,z] in sources_coordinates[1:2]:
+                #Prevent change and raise warning about overlaping positions
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=sources_coordinates[0][0], y1_out=sources_coordinates[0][1], z1_out=sources_coordinates[0][2],
                     x2_out=x2_in, y2_out=y2_in, z2_out=z2_in,
@@ -260,6 +276,7 @@ def update_source(sources_coordinates_input,sources_display_input,x1_in,y1_in,z1
                     warning1=True,warning2=False,warning3=False,
                     new_warning=False)
             else:
+                #If positions aren't overlaping, change the position of first source
                 sources_coordinates[0] = [x,y,z]
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x, y1_out=y, z1_out=z,
@@ -268,7 +285,9 @@ def update_source(sources_coordinates_input,sources_display_input,x1_in,y1_in,z1
                     warning1=False,warning2=False,warning3=False,
                     new_warning=False)
         elif len(sources_coordinates)==2:
+            #Checking if changed position isn't overlaping with already existing ones    
             if [x,y,z] in sources_coordinates[1]:
+                #Prevent change and raise warning about overlaping positions
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=sources_coordinates[0][0], y1_out=sources_coordinates[0][1], z1_out=sources_coordinates[0][2],
                     x2_out=x2_in, y2_out=y2_in, z2_out=z2_in,
@@ -276,6 +295,7 @@ def update_source(sources_coordinates_input,sources_display_input,x1_in,y1_in,z1
                     warning1=True,warning2=False,warning3=False,
                     new_warning=False)
             else:
+                #If positions aren't overlaping, change the position of first source
                 sources_coordinates[0] = [x,y,z]
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x, y1_out=y, z1_out=z,
@@ -284,6 +304,7 @@ def update_source(sources_coordinates_input,sources_display_input,x1_in,y1_in,z1
                     warning1=False,warning2=False,warning3=False,
                     new_warning=False)
         elif len(sources_coordinates)==1:
+            #There's only one source so we can change the postion
             sources_coordinates[0] = [x,y,z]
             return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x, y1_out=y, z1_out=z,
@@ -292,11 +313,15 @@ def update_source(sources_coordinates_input,sources_display_input,x1_in,y1_in,z1
                     warning1=False,warning2=False,warning3=False,
                     new_warning=False)
         else:
+            #Prevent auto update when we don't have any sources
             raise PreventUpdate
+    #Changing second source's postion
     if ctx.triggered_id=="secondary_source_x_coordinate" or ctx.triggered_id=="secondary_source_y_coordinate"  or ctx.triggered_id=="secondary_source_z_coordinate":
         x,y,z = x2_in, y2_in, z2_in
-        if len(sources_coordinates)==3:    
+        if len(sources_coordinates)==3:
+            #Checking if changed position isn't overlaping with already existing ones    
             if [x,y,z] in [sources_coordinates[0],sources_coordinates[2]]:
+                #Prevent change and raise warning about overlaping positions
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x1_in, y1_out=y1_in, z1_out=z1_in,
                     x2_out=sources_coordinates[1][0], y2_out=sources_coordinates[1][1], z2_out=sources_coordinates[1][2],
@@ -304,6 +329,7 @@ def update_source(sources_coordinates_input,sources_display_input,x1_in,y1_in,z1
                     warning1=False,warning2=True,warning3=False,
                     new_warning=False)
             else:
+                #If positions aren't overlaping, change the position of second source
                 sources_coordinates[1] = [x,y,z]
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x1_in, y1_out=y1_in, z1_out=z1_in,
@@ -312,7 +338,9 @@ def update_source(sources_coordinates_input,sources_display_input,x1_in,y1_in,z1
                     warning1=False,warning2=False,warning3=False,
                     new_warning=False)
         elif len(sources_coordinates)==2:
+            #Checking if changed position isn't overlaping with already existing ones
             if [x,y,z] in sources_coordinates[0]:
+                #Prevent change and raise warning about overlaping positions
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x1_in, y1_out=y1_in, z1_out=z1_in,
                     x2_out=sources_coordinates[1][0], y2_out=sources_coordinates[1][1], z2_out=sources_coordinates[1][2],
@@ -320,6 +348,7 @@ def update_source(sources_coordinates_input,sources_display_input,x1_in,y1_in,z1
                     warning1=False,warning2=True,warning3=False,
                     new_warning=False)
             else:
+                #If positions aren't overlaping, change the position of second source
                 sources_coordinates[1] = [x,y,z]
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x1_in, y1_out=y1_in, z1_out=z1_in,
@@ -328,11 +357,15 @@ def update_source(sources_coordinates_input,sources_display_input,x1_in,y1_in,z1
                     warning1=False,warning2=False,warning3=False,
                     new_warning=False)
         else:
+            #Prevent auto update when we don't have any sources
             raise PreventUpdate
+    #Changing third source's postion
     if ctx.triggered_id=="third_source_x_coordinate" or ctx.triggered_id=="third_source_y_coordinate"  or ctx.triggered_id=="third_source_z_coordinate":
         x,y,z = x3_in, y3_in, z3_in
-        if len(sources_coordinates)==3:    
+        if len(sources_coordinates)==3:   
+            #Checking if changed position isn't overlaping with already existing ones 
             if [x,y,z] in [sources_coordinates[0],sources_coordinates[1]]:
+                #Prevent change and raise warning about overlaping positions
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x1_in, y1_out=y1_in, z1_out=z1_in,
                     x2_out=x2_in, y2_out=y2_in, z2_out=z2_in,
@@ -340,6 +373,7 @@ def update_source(sources_coordinates_input,sources_display_input,x1_in,y1_in,z1
                     warning1=False,warning2=False,warning3=True,
                     new_warning=False)
             else:
+                #If positions aren't overlaping, change the position of third source
                 sources_coordinates[2] = [x,y,z]
                 return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x1_in, y1_out=y1_in, z1_out=z1_in,
@@ -348,7 +382,9 @@ def update_source(sources_coordinates_input,sources_display_input,x1_in,y1_in,z1
                     warning1=False,warning2=False,warning3=False,
                     new_warning=False)
         else:
+            #Prevent auto update when we don't have any sources
             raise PreventUpdate
+    #Preventing postions when we refresh app
     if len(sources_coordinates) == 0:
         return dict(sources_coordinates_output=sources_coordinates,sources_display_output=sources_display,
                     x1_out=x1_in, y1_out=y1_in, z1_out=z1_in,
@@ -383,13 +419,17 @@ def update_source(sources_coordinates_input,sources_display_input,x1_in,y1_in,z1
                     x3_out=x3, y3_out=y3, z3_out=z3,
                     warning1=False,warning2=False,warning3=False,
                     new_warning=False)
-    raise PreventUpdate
+    
+    raise PreventUpdate #Just in case if we get here, to prevent rasing errror
 
 @callback(
     [Output("primary_source_position_parameters", "style"),Output("secondary_source_position_parameters", "style"),Output("third_source_position_parameters", "style")],
     Input("sources_display_list","data"),
 )
-def update_number_of_sources(sources_display_list):
+def update_sources_display(sources_display_list):
+    """
+    Updating sources display 
+    """
     return sources_display_list
 
 @callback(
@@ -401,13 +441,13 @@ def update_number_of_sources(sources_display_list):
 )
 def disable_source_buttons(sources_coordinates_list,add_source, remove_source):
 
-    if len(sources_coordinates_list) == 0:
+    if len(sources_coordinates_list) == 0:#Disable remove button, because we don't have any sources
         return False, True
     
-    if len(sources_coordinates_list) < 3:
+    if len(sources_coordinates_list) < 3 and len(sources_coordinates_list)>0:#You can add and remove sources. At least one source, but below limit
         return False, False
     
-    if len(sources_coordinates_list) == 3:
+    if len(sources_coordinates_list) >= 3:#Disable adding button, because we have reached the limit
         return True, False
 
 @callback(
@@ -420,6 +460,9 @@ def disable_source_buttons(sources_coordinates_list,add_source, remove_source):
     Input("dim_z", "value")
 )
 def update_source_coordinate_max(dim_x, dim_y, dim_z):
+    """
+    Updating maximum value of source postion, so it's in the ROI
+    """
     return 4*[dim_x, dim_y, dim_z]
 
 if __name__ == '__main__':

--- a/app.py
+++ b/app.py
@@ -104,11 +104,11 @@ app.layout = html.Div([
                                             html.Div(id="add_source_position_parameters", style={"display":"block"},
                                                     children=[                                            
                                                         html.Label("X (mm): ", htmlFor="add_source_x_coordinate"),
-                                                        dcc.Input(id="add_source_x_coordinate", type="number", min=0, step=0.001, value=0, debounce=True),
+                                                        dcc.Input(id="add_source_x_coordinate", type="number", min=0, step=0.001, value=0),
                                                         html.Label("Y (mm): ", htmlFor="add_source_y_coordinate"),
-                                                        dcc.Input(id="add_source_y_coordinate", type="number", min=0, step=0.001, value=0, debounce=True),
+                                                        dcc.Input(id="add_source_y_coordinate", type="number", min=0, step=0.001, value=0),
                                                         html.Label("Z (mm): ", htmlFor="add_source_z_coordinate"),
-                                                        dcc.Input(id="add_source_z_coordinate", type="number", min=0, step=0.001, value=0, debounce=True),
+                                                        dcc.Input(id="add_source_z_coordinate", type="number", min=0, step=0.001, value=0),
                                                         html.Button("Add source", id="add_source", n_clicks=0, disabled=False),
                                                         dcc.ConfirmDialog(id="sources_with_overlapping_coordinates", message="Can't add source because of overlapping coordinates")
                                                     ]),


### PR DESCRIPTION
Added Laser Position Settings
It prevents overlapping positions (with warning) and preserve values during session, when refreshing app.
Auto updates range, so we don't set position outside of ROI.
Auto updates display based on No. of sources.
No. of source's limit is 3, buttons are disabled, preventing from going outside of limit.